### PR TITLE
Backend for endorsement feature (do not accept)

### DIFF
--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -22,6 +22,9 @@ PostObject:
       type: number
     votes:
       type: number
+    endorsedBy:
+      type: number
+      nullable: true
     timestampISO:
       type: string
       description: An ISO 8601 formatted date string (complementing `timestamp`)

--- a/public/openapi/write/posts/pid.yaml
+++ b/public/openapi/write/posts/pid.yaml
@@ -64,6 +64,21 @@ get:
                     type: boolean
                   downvoted:
                     type: boolean
+                  endorsedBy:
+                    type: number
+                    description: ID of the user who endorsed the post
+            required:
+              - pid
+              - uid
+              - tid
+              - content
+              - timestamp
+              - upvotes
+              - downvotes
+              - timestampISO
+              - upvoted
+              - downvoted
+              - endorsedBy
 put:
   tags:
     - posts

--- a/public/openapi/write/posts/pid/endorse.yaml
+++ b/public/openapi/write/posts/pid/endorse.yaml
@@ -1,0 +1,26 @@
+put:
+  tags:
+    - posts
+  summary: endorse a post
+  description: This operation endorses a post.
+  parameters:
+    - in: path
+      name: pid
+      schema:
+        type: string
+      required: true
+      description: a valid post id
+      example: 2
+  responses:
+    '200':
+      description: Post successfully endorsed
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                $ref: ../../../components/schemas/Status.yaml#/Status
+              response:
+                type: object
+                properties: {}

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -308,6 +308,20 @@ postsAPI.unvote = async function (caller, data) {
 	return await apiHelpers.postCommand(caller, 'unvote', 'voted', '', data);
 };
 
+postsAPI.endorse = async function (caller, data) {
+	if (!data || !data.pid || !data.uid) {
+		throw new Error('[[error:invalid-data]]');
+	}
+	await posts.endorse(data.pid, data.uid);
+};
+
+postsAPI.unendorse = async function (caller, data) {
+    if (!data || !data.pid || !data.uid) {
+        throw new Error('[[error:invalid-data]]');
+    }
+    await posts.unendorse(data.pid, data.uid);
+};
+
 postsAPI.getVoters = async function (caller, data) {
 	if (!data || !data.pid) {
 		throw new Error('[[error:invalid-data]]');

--- a/src/controllers/write/posts.js
+++ b/src/controllers/write/posts.js
@@ -153,6 +153,18 @@ Posts.unbookmark = async (req, res) => {
 	helpers.formatApiResponse(200, res);
 };
 
+Posts.endorse = async (req, res) => {
+    const { pid, uid } = req.body;
+    await api.posts.endorse(req, { pid, uid });
+    helpers.formatApiResponse(200, res);
+};
+
+Posts.unendorse = async (req, res) => {
+    const { pid, uid } = req.body;
+    await api.posts.unendorse(req, { pid, uid });
+    helpers.formatApiResponse(200, res);
+};
+
 Posts.getDiffs = async (req, res) => {
 	helpers.formatApiResponse(200, res, await api.posts.getDiffs(req, { ...req.params }));
 };

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -67,5 +67,8 @@ function modifyPost(post, fields) {
 		if (post.hasOwnProperty('edited')) {
 			post.editedISO = post.edited !== 0 ? utils.toISOString(post.edited) : '';
 		}
+		if (post.hasOwnProperty('endorsedBy')) {
+			post.endorsedBy = post.endorsedBy ? post.endorsedBy : null;
+		}
 	}
 }

--- a/src/posts/endorsements.js
+++ b/src/posts/endorsements.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = function (Posts) {
+    Posts.endorse = async function (pid, uid) {
+        const postData = await Posts.getPostFields(pid, ['endorsedBy']);
+        if (postData.endorsedBy) {
+            throw new Error('[[error:post-already-endorsed]]');
+        }
+        await Posts.setPostField(pid, 'endorsedBy', uid);
+    };
+
+    Posts.unendorse = async function (pid, uid) {
+        const postData = await Posts.getPostFields(pid, ['endorsedBy']);
+        if (postData.endorsedBy === uid) {
+            await Posts.setPostField(pid, 'endorsedBy', null);
+        } else {
+            throw new Error('[[error:not-endorsed-by-user]]');
+        }
+    };
+};

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -20,7 +20,7 @@ module.exports = function (Posts) {
 		options.parse = options.hasOwnProperty('parse') ? options.parse : true;
 		options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-		const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
+		const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle', 'endorsedBy'].concat(options.extraFields);
 
 		let posts = await Posts.getPostsFields(pids, fields);
 		posts = posts.filter(Boolean);

--- a/src/posts/votes.js
+++ b/src/posts/votes.js
@@ -98,6 +98,23 @@ module.exports = function (Posts) {
 		return await db.getSetsMembers(pids.map(pid => `pid:${pid}:upvote`));
 	};
 
+	Posts.endorse = async function (pid, uid) {
+		const postData = await Posts.getPostFields(pid, ['endorsedBy']);
+		if (postData.endorsedBy) {
+			throw new Error('[[error:post-already-endorsed]]');
+		}
+		await Posts.setPostField(pid, 'endorsedBy', uid);
+	};
+
+	Posts.unendorse = async function (pid, uid) {
+		const postData = await Posts.getPostFields(pid, ['endorsedBy']);
+		if (postData.endorsedBy === uid) {
+			await Posts.setPostField(pid, 'endorsedBy', null);
+		} else {
+			throw new Error('[[error:not-endorsed-by-user]]');
+		}
+	};
+
 	function voteInProgress(pid, uid) {
 		return Array.isArray(votesInProgress[uid]) && votesInProgress[uid].includes(parseInt(pid, 10));
 	}

--- a/src/routes/write/posts.js
+++ b/src/routes/write/posts.js
@@ -32,6 +32,8 @@ module.exports = function () {
 	setupApiRoute(router, 'put', '/:pid/bookmark', middlewares, controllers.write.posts.bookmark);
 	setupApiRoute(router, 'delete', '/:pid/bookmark', middlewares, controllers.write.posts.unbookmark);
 
+	setupApiRoute(router, 'post', '/:pid/endorse', middlewares, controllers.write.posts.endorse);
+    setupApiRoute(router, 'post', '/:pid/unendorse', middlewares, controllers.write.posts.unendorse);
 	setupApiRoute(router, 'get', '/:pid/diffs', [middleware.assert.post], controllers.write.posts.getDiffs);
 	setupApiRoute(router, 'get', '/:pid/diffs/:since', [middleware.assert.post], controllers.write.posts.loadDiff);
 	setupApiRoute(router, 'put', '/:pid/diffs/:since', middlewares, controllers.write.posts.restoreDiff);

--- a/src/socket.io/posts.js
+++ b/src/socket.io/posts.js
@@ -20,6 +20,7 @@ const SocketPosts = module.exports;
 
 require('./posts/votes')(SocketPosts);
 require('./posts/tools')(SocketPosts);
+require('./posts/endorsements')(SocketPosts);
 
 SocketPosts.getRawPost = async function (socket, pid) {
 	sockets.warnDeprecated(socket, 'GET /api/v3/posts/:pid/raw');

--- a/src/socket.io/posts/endorsements.js
+++ b/src/socket.io/posts/endorsements.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const api = require('../../api');
+const sockets = require('../index');
+
+module.exports = function (SocketPosts) {
+    SocketPosts.endorse = async function (socket, data) {
+        if (!data || !data.pid || !data.uid) {
+            throw new Error('[[error:invalid-data]]');
+        }
+        sockets.warnDeprecated(socket, 'POST /api/v3/posts/:pid/endorse');
+        return await api.posts.endorse(socket, { pid: data.pid, uid: data.uid });
+    };
+
+    SocketPosts.unendorse = async function (socket, data) {
+        if (!data || !data.pid || !data.uid) {
+            throw new Error('[[error:invalid-data]]');
+        }
+        sockets.warnDeprecated(socket, 'POST /api/v3/posts/:pid/unendorse');
+        return await api.posts.unendorse(socket, { pid: data.pid, uid: data.uid });
+    };
+};


### PR DESCRIPTION
Added backend logic for allowing professors or TAs to endorse a post and wrote a test suite for it. 

Made edits to Post's schema, controller, API, and test suite. 

Resolves #5 

Open Bugs: Code is not passing the test written to unendorse a post.

NOTE: This pull request will remain unmerged due to implementation not fully working. We will consider rolling over this issue to Sprint 2 where it may be reassigned to another team member.