### PR TITLE
added boolean field 'endorsed' to Post

### DIFF
--- a/public/openapi/components/schemas/PostObject.yaml
+++ b/public/openapi/components/schemas/PostObject.yaml
@@ -22,6 +22,8 @@ PostObject:
       type: number
     votes:
       type: number
+    endorsed:
+      type: boolean
     timestampISO:
       type: string
       description: An ISO 8601 formatted date string (complementing `timestamp`)

--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -71,6 +71,8 @@ get:
                           type: number
                         downvotes:
                           type: number
+                        endorsed:
+                          type: number
                         bookmarks:
                           type: number
                         deleterUid:

--- a/public/openapi/write/posts/pid.yaml
+++ b/public/openapi/write/posts/pid.yaml
@@ -54,6 +54,8 @@ get:
                     type: number
                   votes:
                     type: number
+                  endorsed:
+                    type: number
                   timestampISO:
                     type: string
                     description: An ISO 8601 formatted date string (complementing `timestamp`)

--- a/public/openapi/write/posts/pid/replies.yaml
+++ b/public/openapi/write/posts/pid/replies.yaml
@@ -51,6 +51,8 @@ get:
                           type: number
                         bookmarks:
                           type: number
+                        endorsed:
+                          type: number
                         deleterUid:
                           type: number
                         edited:

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -36,7 +36,7 @@ module.exports = function (Posts) {
 			tid: tid,
 			content: content,
 			timestamp: timestamp,
-			endorsed: endorsed
+			endorsed: endorsed,
 		};
 
 		if (data.toPid) {

--- a/src/posts/create.js
+++ b/src/posts/create.js
@@ -19,6 +19,7 @@ module.exports = function (Posts) {
 		const content = data.content.toString();
 		const timestamp = data.timestamp || Date.now();
 		const isMain = data.isMain || false;
+		const endorsed = data.endorsed || false;
 
 		if (!uid && parseInt(uid, 10) !== 0) {
 			throw new Error('[[error:invalid-uid]]');
@@ -35,6 +36,7 @@ module.exports = function (Posts) {
 			tid: tid,
 			content: content,
 			timestamp: timestamp,
+			endorsed: endorsed
 		};
 
 		if (data.toPid) {

--- a/src/posts/data.js
+++ b/src/posts/data.js
@@ -6,7 +6,7 @@ const utils = require('../utils');
 
 const intFields = [
 	'uid', 'pid', 'tid', 'deleted', 'timestamp',
-	'upvotes', 'downvotes', 'deleterUid', 'edited',
+	'upvotes', 'downvotes', 'endorsed', 'deleterUid', 'edited',
 	'replies', 'bookmarks',
 ];
 
@@ -66,6 +66,10 @@ function modifyPost(post, fields) {
 		}
 		if (post.hasOwnProperty('edited')) {
 			post.editedISO = post.edited !== 0 ? utils.toISOString(post.edited) : '';
+		}
+
+		if (post.hasOwnProperty('endorsed')) {
+			post.endorsed = post.endorsed ? post.endorsed : false;
 		}
 	}
 }

--- a/src/posts/delete.js
+++ b/src/posts/delete.js
@@ -26,7 +26,7 @@ module.exports = function (Posts) {
 			deleted: isDeleting ? 1 : 0,
 			deleterUid: isDeleting ? uid : 0,
 		});
-		const postData = await Posts.getPostFields(pid, ['pid', 'tid', 'uid', 'content', 'timestamp']);
+		const postData = await Posts.getPostFields(pid, ['pid', 'tid', 'uid', 'content', 'endorsed', 'timestamp']);
 		const topicData = await topics.getTopicFields(postData.tid, ['tid', 'cid', 'pinned']);
 		postData.cid = topicData.cid;
 		await Promise.all([

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -51,7 +51,7 @@ module.exports = function (Posts) {
 			post.category = post.topic && cidToCategory[post.topic.cid];
 			post.isMainPost = post.topic && post.pid === post.topic.mainPid;
 			post.deleted = post.deleted === 1;
-			post.endorsed = post.endorsed;
+			post.endorsed = post.endorsed === true;
 			post.timestampISO = utils.toISOString(post.timestamp);
 		});
 

--- a/src/posts/summary.js
+++ b/src/posts/summary.js
@@ -20,7 +20,7 @@ module.exports = function (Posts) {
 		options.parse = options.hasOwnProperty('parse') ? options.parse : true;
 		options.extraFields = options.hasOwnProperty('extraFields') ? options.extraFields : [];
 
-		const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'replies', 'handle'].concat(options.extraFields);
+		const fields = ['pid', 'tid', 'content', 'uid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'endorsed', 'replies', 'handle'].concat(options.extraFields);
 
 		let posts = await Posts.getPostsFields(pids, fields);
 		posts = posts.filter(Boolean);
@@ -51,6 +51,7 @@ module.exports = function (Posts) {
 			post.category = post.topic && cidToCategory[post.topic.cid];
 			post.isMainPost = post.topic && post.pid === post.topic.mainPid;
 			post.deleted = post.deleted === 1;
+			post.endorsed = post.endorsed;
 			post.timestampISO = utils.toISOString(post.timestamp);
 		});
 

--- a/src/posts/user.js
+++ b/src/posts/user.js
@@ -140,7 +140,7 @@ module.exports = function (Posts) {
 			throw new Error('[[error:no-user]]');
 		}
 		let postData = await Posts.getPostsFields(pids, [
-			'pid', 'tid', 'uid', 'content', 'deleted', 'timestamp', 'upvotes', 'downvotes',
+			'pid', 'tid', 'uid', 'content', 'deleted', 'endorsed', 'timestamp', 'upvotes', 'downvotes',
 		]);
 		postData = postData.filter(p => p.pid && p.uid !== parseInt(toUid, 10));
 		pids = postData.map(p => p.pid);

--- a/src/search.js
+++ b/src/search.js
@@ -177,7 +177,7 @@ async function filterAndSort(pids, data) {
 }
 
 async function getMatchedPosts(pids, data) {
-	const postFields = ['pid', 'uid', 'tid', 'timestamp', 'deleted', 'upvotes', 'downvotes'];
+	const postFields = ['pid', 'uid', 'tid', 'timestamp', 'deleted', 'upvotes', 'downvotes', 'endorsed'];
 
 	let postsData = await posts.getPostsFields(pids, postFields);
 	postsData = postsData.filter(post => post && !post.deleted);

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -120,6 +120,9 @@ module.exports = function (Topics) {
 		const tid = await Topics.create(data);
 
 		let postData = data;
+		if (postData.endorsed === undefined) {
+			postData.endorsed = false;
+		}
 		postData.tid = tid;
 		postData.ip = data.req ? data.req.ip : null;
 		postData.isMain = true;

--- a/src/topics/fork.js
+++ b/src/topics/fork.js
@@ -92,7 +92,7 @@ module.exports = function (Topics) {
 		if (!forceScheduled && topicData.scheduled) {
 			throw new Error('[[error:cant-move-posts-to-scheduled]]');
 		}
-		const postData = await posts.getPostFields(pid, ['tid', 'uid', 'timestamp', 'upvotes', 'downvotes']);
+		const postData = await posts.getPostFields(pid, ['tid', 'uid', 'timestamp', 'upvotes', 'downvotes', 'endorsed']);
 		if (!postData || !postData.tid) {
 			throw new Error('[[error:no-post]]');
 		}


### PR DESCRIPTION
Resolves #24 

Added a boolean field named 'endorsed' to a Post. I modeled it off of Post's other boolean fields like deleted.

Able to see the "endorsed" attribute when you go to localhost:4567/api/topic/#

![image](https://github.com/user-attachments/assets/b960967e-92d1-4e69-9f36-35e3fb728a76)

The following files were changed because existing tests were failing:
- `src/posts/create.js`: Endorsed is default set to false
- `src/posts/data.js`: Added it as a field and checks if post has it as its own property
- `src/posts/user.js`: Added it to getPostsFields as it is a new field in post
- `src/search.js`: Was getting errors in api/serach so added it as a field to postFields
- `src/topics/create.js`: Defaults to false if posts.endorsed is undefined
- `src/topics/fork.js`: Added it as a field to getPostFields. 