### PR TITLE
Created and test endorsement API with no authorization 

### DIFF
--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -512,3 +512,11 @@ postsAPI.getReplies = async (caller, { pid }) => {
 
 	return postData;
 };
+
+postsAPI.endorse = async (caller, { pid }) => {
+    return await posts.endorse(pid, caller.uid);
+};
+
+postsAPI.unendorse = async (caller, { pid }) => {
+    return await posts.unendorse(pid, caller.uid);
+};

--- a/src/api/posts.js
+++ b/src/api/posts.js
@@ -513,10 +513,6 @@ postsAPI.getReplies = async (caller, { pid }) => {
 	return postData;
 };
 
-postsAPI.endorse = async (caller, { pid }) => {
-    return await posts.endorse(pid, caller.uid);
-};
+postsAPI.endorse = async (caller, { pid }) => await posts.endorse(pid, caller.uid);
 
-postsAPI.unendorse = async (caller, { pid }) => {
-    return await posts.unendorse(pid, caller.uid);
-};
+postsAPI.unendorse = async (caller, { pid }) => await posts.unendorse(pid, caller.uid);

--- a/src/posts/endorsements.js
+++ b/src/posts/endorsements.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const db = require('../database');
+const plugins = require('../plugins');
+
+module.exports = function (Posts) {
+    Posts.endorse = async function (pid, uid) {
+        return await toggleEndorse('endorse', pid, uid);
+    };
+
+    Posts.unendorse = async function (pid, uid) {
+        return await toggleEndorse('unendorse', pid, uid);
+    };
+
+    async function toggleEndorse(type, pid, uid) {
+        if (parseInt(uid, 10) <= 0) {
+            throw new Error('[[error:not-logged-in]]');
+        }
+
+        const isEndorsing = type === 'endorse';
+
+        const [postData, hasEndorsed] = await Promise.all([
+            Posts.getPostFields(pid, ['pid', 'uid']),
+            Posts.hasEndorsed(pid, uid),
+        ]);
+
+        if (isEndorsing) {
+            await db.setAdd(`pid:${pid}:users_endorsed`, uid);
+        } else {
+            await db.setRemove(`pid:${pid}:users_endorsed`, uid);
+        }
+        postData.endorsed = await db.setCount(`pid:${pid}:users_endorsed`);
+        await Posts.setPostField(pid, 'endorsed', postData.endorsed);
+
+        plugins.hooks.fire(`action:post.${type}`, {
+            pid: pid,
+            uid: uid,
+            owner: postData.uid,
+            current: hasEndorsed ? 'endorsed' : 'unendorsed',
+        });
+
+        return {
+            post: postData,
+            isEndorsed: isEndorsing,
+        };
+    }
+
+    Posts.hasEndorsed = async function (pid, uid) {
+        if (parseInt(uid, 10) <= 0) {
+            return Array.isArray(pid) ? pid.map(() => false) : false;
+        }
+
+        if (Array.isArray(pid)) {
+            const sets = pid.map(pid => `pid:${pid}:users_endorsed`);
+            return await db.isMemberOfSets(sets, uid);
+        }
+        return await db.isSetMember(`pid:${pid}:users_endorsed`, uid);
+    };
+};

--- a/src/posts/endorsements.js
+++ b/src/posts/endorsements.js
@@ -4,56 +4,56 @@ const db = require('../database');
 const plugins = require('../plugins');
 
 module.exports = function (Posts) {
-    Posts.endorse = async function (pid, uid) {
-        return await toggleEndorse('endorse', pid, uid);
-    };
+	Posts.endorse = async function (pid, uid) {
+		return await toggleEndorse('endorse', pid, uid);
+	};
 
-    Posts.unendorse = async function (pid, uid) {
-        return await toggleEndorse('unendorse', pid, uid);
-    };
+	Posts.unendorse = async function (pid, uid) {
+		return await toggleEndorse('unendorse', pid, uid);
+	};
 
-    async function toggleEndorse(type, pid, uid) {
-        if (parseInt(uid, 10) <= 0) {
-            throw new Error('[[error:not-logged-in]]');
-        }
+	async function toggleEndorse(type, pid, uid) {
+		if (parseInt(uid, 10) <= 0) {
+			throw new Error('[[error:not-logged-in]]');
+		}
 
-        const isEndorsing = type === 'endorse';
+		const isEndorsing = type === 'endorse';
 
-        const [postData, hasEndorsed] = await Promise.all([
-            Posts.getPostFields(pid, ['pid', 'uid']),
-            Posts.hasEndorsed(pid, uid),
-        ]);
+		const [postData, hasEndorsed] = await Promise.all([
+			Posts.getPostFields(pid, ['pid', 'uid']),
+			Posts.hasEndorsed(pid, uid),
+		]);
 
-        if (isEndorsing) {
-            await db.setAdd(`pid:${pid}:users_endorsed`, uid);
-        } else {
-            await db.setRemove(`pid:${pid}:users_endorsed`, uid);
-        }
-        postData.endorsed = await db.setCount(`pid:${pid}:users_endorsed`);
-        await Posts.setPostField(pid, 'endorsed', postData.endorsed);
+		if (isEndorsing) {
+			await db.setAdd(`pid:${pid}:users_endorsed`, uid);
+		} else {
+			await db.setRemove(`pid:${pid}:users_endorsed`, uid);
+		}
+		postData.endorsed = await db.setCount(`pid:${pid}:users_endorsed`);
+		await Posts.setPostField(pid, 'endorsed', postData.endorsed);
 
-        plugins.hooks.fire(`action:post.${type}`, {
-            pid: pid,
-            uid: uid,
-            owner: postData.uid,
-            current: hasEndorsed ? 'endorsed' : 'unendorsed',
-        });
+		plugins.hooks.fire(`action:post.${type}`, {
+			pid: pid,
+			uid: uid,
+			owner: postData.uid,
+			current: hasEndorsed ? 'endorsed' : 'unendorsed',
+		});
 
-        return {
-            post: postData,
-            isEndorsed: isEndorsing,
-        };
-    }
+		return {
+			post: postData,
+			isEndorsed: isEndorsing,
+		};
+	}
 
-    Posts.hasEndorsed = async function (pid, uid) {
-        if (parseInt(uid, 10) <= 0) {
-            return Array.isArray(pid) ? pid.map(() => false) : false;
-        }
+	Posts.hasEndorsed = async function (pid, uid) {
+		if (parseInt(uid, 10) <= 0) {
+			return Array.isArray(pid) ? pid.map(() => false) : false;
+		}
 
-        if (Array.isArray(pid)) {
-            const sets = pid.map(pid => `pid:${pid}:users_endorsed`);
-            return await db.isMemberOfSets(sets, uid);
-        }
-        return await db.isSetMember(`pid:${pid}:users_endorsed`, uid);
-    };
+		if (Array.isArray(pid)) {
+			const sets = pid.map(pid => `pid:${pid}:users_endorsed`);
+			return await db.isMemberOfSets(sets, uid);
+		}
+		return await db.isSetMember(`pid:${pid}:users_endorsed`, uid);
+	};
 };

--- a/src/posts/index.js
+++ b/src/posts/index.js
@@ -26,6 +26,7 @@ require('./bookmarks')(Posts);
 require('./queue')(Posts);
 require('./diffs')(Posts);
 require('./uploads')(Posts);
+require('./endorsements')(Posts);
 
 Posts.exists = async function (pids) {
 	return await db.exists(

--- a/src/socket.io/posts/tools.js
+++ b/src/socket.io/posts/tools.js
@@ -11,6 +11,7 @@ const plugins = require('../../plugins');
 const social = require('../../social');
 const user = require('../../user');
 const utils = require('../../utils');
+const apiPosts = require('../../api/posts');
 
 module.exports = function (SocketPosts) {
 	SocketPosts.loadPostTools = async function (socket, data) {
@@ -91,5 +92,19 @@ module.exports = function (SocketPosts) {
 		})));
 
 		await Promise.all(logs);
+	};
+
+	SocketPosts.endorse = async function (socket, data) {
+		if (!data || !data.pid) {
+			throw new Error('[[error:invalid-data]]');
+		}
+		return await apiPosts.endorse(socket, { pid: data.pid });
+	};
+
+	SocketPosts.unendorse = async function (socket, data) {
+		if (!data || !data.pid) {
+			throw new Error('[[error:invalid-data]]');
+		}
+		return await apiPosts.unendorse(socket, { pid: data.pid });
 	};
 };

--- a/test/posts.js
+++ b/test/posts.js
@@ -132,6 +132,37 @@ describe('Post\'s', () => {
 		});
 	});
 
+	describe('endorsing and unendorsing', function () {
+        let testPid;
+        let testUid;
+
+        before(async () => {
+            testUid = await user.create({ username: 'endorser' });
+            const postResult = await topics.post({
+                uid: testUid,
+                cid: cid,
+                title: 'test topic for endorsement feature',
+                content: 'endorsement topic content',
+            });
+            testPid = postResult.postData.pid;
+        });
+
+        it('should mark post as endorsed', async function () {
+            const caller = { uid: testUid };
+            const data = { pid: testPid };
+            const result = await apiPosts.endorse(caller, data);
+            assert.strictEqual(result.isEndorsed, true);
+        });
+
+        it('should change post to unendorsed', async function () {
+            await apiPosts.endorse({ uid: testUid }, { pid: testPid }); 
+            const caller = { uid: testUid };
+            const data = { pid: testPid };
+            const result = await apiPosts.unendorse(caller, data);
+            assert.strictEqual(result.isEndorsed, false);
+        });
+    });
+
 	describe('voting', () => {
 		it('should fail to upvote post if group does not have upvote permission', async () => {
 			await privileges.categories.rescind(['groups:posts:upvote', 'groups:posts:downvote'], cid, 'registered-users');

--- a/test/posts.js
+++ b/test/posts.js
@@ -132,36 +132,33 @@ describe('Post\'s', () => {
 		});
 	});
 
-	describe('endorsing and unendorsing', function () {
-        let testPid;
-        let testUid;
-
-        before(async () => {
-            testUid = await user.create({ username: 'endorser' });
-            const postResult = await topics.post({
-                uid: testUid,
-                cid: cid,
-                title: 'test topic for endorsement feature',
-                content: 'endorsement topic content',
-            });
-            testPid = postResult.postData.pid;
-        });
-
-        it('should mark post as endorsed', async function () {
-            const caller = { uid: testUid };
-            const data = { pid: testPid };
-            const result = await apiPosts.endorse(caller, data);
-            assert.strictEqual(result.isEndorsed, true);
-        });
-
-        it('should change post to unendorsed', async function () {
-            await apiPosts.endorse({ uid: testUid }, { pid: testPid }); 
-            const caller = { uid: testUid };
-            const data = { pid: testPid };
-            const result = await apiPosts.unendorse(caller, data);
-            assert.strictEqual(result.isEndorsed, false);
-        });
-    });
+	describe('endorsing and unendorsing', () => {
+		let testPid;
+		let testUid;
+		before(async () => {
+			testUid = await user.create({ username: 'endorser' });
+			const postResult = await topics.post({
+				uid: testUid,
+				cid: cid,
+				title: 'test topic for endorsement feature',
+				content: 'endorsement topic content',
+			});
+			testPid = postResult.postData.pid;
+		});
+		it('should mark post as endorsed', async () => {
+			const caller = { uid: testUid };
+			const data = { pid: testPid };
+			const result = await apiPosts.endorse(caller, data);
+			assert.strictEqual(result.isEndorsed, true);
+		});
+		it('should change post to unendorsed', async () => {
+			await apiPosts.endorse({ uid: testUid }, { pid: testPid });
+			const caller = { uid: testUid };
+			const data = { pid: testPid };
+			const result = await apiPosts.unendorse(caller, data);
+			assert.strictEqual(result.isEndorsed, false);
+		});
+	});
 
 	describe('voting', () => {
 		it('should fail to upvote post if group does not have upvote permission', async () => {


### PR DESCRIPTION
Resolves #34 

Created API endpoints for endorsing and unendorsing, allowing any logged in user to flip the endorsed boolean field on a post. I took inspiration from bookmark's API. 

Edited the following files:
- `src/api/posts.js`: connecting the existing postsAPI to the endorse function
- `src/posts/endorsements.js`: Changes the database with the new value for endorsed
- `src/posts/index.js`: Added in require to route properly
- `src/socket.io/posts/tools.js`: Added in here because was not passing other existing test cases.
- `test/posts.js`: Developed unit tests to endorse and unendorse a test post. 

The current implementation does not check the requesting user's group as that is #26 and I also want to develop incrementally and push out changes to team members to allow for parallel development. 