### PR TITLE
Writing test case to ensure endorsed work upon initialization

### DIFF
--- a/test/posts/create.js
+++ b/test/posts/create.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const assert = require('assert');
+const db = require('../mocks/databasemock');
+const plugins = require('../../src/plugins');
+const user = require('../../src/user');
+const topics = require('../../src/topics');
+const categories = require('../../src/categories');
+const groups = require('../../src/groups');
+const privileges = require('../../src/privileges');
+const meta = require('../../src/meta');
+const Posts = {};
+
+
+describe('create post', function () {
+    let pid;
+	let purgePid;
+	let cid;
+	let uid;
+    let endorsed;
+
+
+    it('create a post', async function () {
+        try {
+            uid = await user.create({
+                username: 'uploads user',
+                password: 'abracadabra',
+                gdpr_consent: 1,
+            });
+    
+            ({ cid } = await categories.create({
+                name: 'Test Category',
+                description: 'Test category created by testing script',
+            }));
+            
+            endorsed = false;
+
+            const topicPostData = await topics.post({
+                uid,
+                cid,
+                title: 'topic with some images',
+                content: 'here is an image [alt text](/assets/uploads/files/abracadabra.png) and another [alt text](/assets/uploads/files/shazam.jpg)',
+                endorsed
+            });
+            } catch (error) {
+            assert.strictEqual(error.message, '[[error:invalid-uid]]');
+        }
+    });
+});
+
+describe('addReplyTo', function () {
+});
+
+describe('checkToPid', function () {
+});

--- a/test/posts/create.js
+++ b/test/posts/create.js
@@ -14,36 +14,39 @@ const Posts = {};
 
 describe('create post', function () {
     let pid;
-	let purgePid;
-	let cid;
-	let uid;
+    let purgePid;
+    let cid;
+    let uid;
     let endorsed;
 
-
-    it('create a post', async function () {
+    it('create a post where endorsed is false', async function () {
         try {
+            // Create a user
             uid = await user.create({
                 username: 'uploads user',
                 password: 'abracadabra',
                 gdpr_consent: 1,
             });
     
+            // Create a test category
             ({ cid } = await categories.create({
                 name: 'Test Category',
                 description: 'Test category created by testing script',
             }));
             
-            endorsed = false;
-
+            // Create a post within the category
             const topicPostData = await topics.post({
                 uid,
                 cid,
                 title: 'topic with some images',
                 content: 'here is an image [alt text](/assets/uploads/files/abracadabra.png) and another [alt text](/assets/uploads/files/shazam.jpg)',
-                endorsed
             });
-            } catch (error) {
-            assert.strictEqual(error.message, '[[error:invalid-uid]]');
+            
+            // Check if 'endorsed' is false
+            endorsed = topicPostData.postData.endorsed;
+            assert.strictEqual(endorsed, false);
+        } catch (error) {
+            console.log(error);
         }
     });
 });

--- a/test/posts/create.js
+++ b/test/posts/create.js
@@ -19,8 +19,7 @@ describe('create post', function () {
     let uid;
     let endorsed;
 
-    it('create a post where endorsed is false', async function () {
-        try {
+    before(async function () {
             // Create a user
             uid = await user.create({
                 username: 'uploads user',
@@ -33,7 +32,10 @@ describe('create post', function () {
                 name: 'Test Category',
                 description: 'Test category created by testing script',
             }));
-            
+    });
+
+    it('create a post where endorsed is automatically false', async function () {
+        try {     
             // Create a post within the category
             const topicPostData = await topics.post({
                 uid,
@@ -41,7 +43,7 @@ describe('create post', function () {
                 title: 'topic with some images',
                 content: 'here is an image [alt text](/assets/uploads/files/abracadabra.png) and another [alt text](/assets/uploads/files/shazam.jpg)',
             });
-            
+       
             // Check if 'endorsed' is false
             endorsed = topicPostData.postData.endorsed;
             assert.strictEqual(endorsed, false);
@@ -49,10 +51,24 @@ describe('create post', function () {
             console.log(error);
         }
     });
+
+    it('create a post where endorsed is initialized to be true', async function () {
+        try {     
+            // Create a post within the category
+            const topicPostData = await topics.post({
+                uid,
+                cid,
+                title: 'topic with some images',
+                content: 'here is an image [alt text](/assets/uploads/files/abracadabra.png) and another [alt text](/assets/uploads/files/shazam.jpg)',
+                endorsed: true
+            });
+       
+            // Check if 'endorsed' is false
+            endorsed = topicPostData.postData.endorsed;
+            assert.strictEqual(endorsed, true);
+        } catch (error) {
+            console.log(error);
+        }
+    });
 });
 
-describe('addReplyTo', function () {
-});
-
-describe('checkToPid', function () {
-});


### PR DESCRIPTION
This issue focuses on validating the behavior of the `endorsed` field in post creation in `test/posts/create.js`, specifically ensuring that the field is correctly initialized based on input parameters. The new test cases in create post cover scenarios where the `endorsed` field should automatically default to false if not specified and correctly initialize to true when explicitly set.

@evelynnchen-cmu since you implemented the back-end, can you take a look at the test case?

Connect with Kanban task: #33 
